### PR TITLE
prefer distro package of psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,17 @@ Requirements
 Installation
 ------------
 
+1. Install your distro's packages for Python 3, virtualenv, and psycopg2. For 
+   example, on Fedora:
+
+   ```
+   yum install python3 python-virtualenv python3-psycopg2
+   ```
+
 1. Activate a virtualenv (ensure it uses Python 3 as 2.x is not supported):
 
    ```
-   $ virtualenv -p python3 ticketus
+   $ virtualenv -p python3 --system-site-packages ticketus
    $ cd ticketus && source bin/activate
    ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Django==1.7.1
 django-debug-toolbar==1.2.2
 django-grappelli==2.6.3
 mistune==0.5
-psycopg2==2.5.4
+psycopg2
 sqlparse==0.1.14


### PR DESCRIPTION
It's simpler to use the distro package for psycopg2 since compiling it
requires headers for Python 3 and Postgres. This way you will also get
all the niceties that distro packages give you like proper debug symbols
and compiler flags.

For the other dependencies it's not much of an issue as they are pure
Python.
